### PR TITLE
Add edit mode and system helpers

### DIFF
--- a/core/src/app.ts
+++ b/core/src/app.ts
@@ -1,11 +1,11 @@
 import { Logger } from "tslog";
 import { Mode } from "./mode";
-import { System } from "./system";
+import { System, Atom } from "./system";
 import { World } from "./world";
 import { Executor } from "./command";
 import { GuiManager } from "./gui";
+import { MeshBuilder } from "@babylonjs/core";
 // import { ArtistGuild } from "./artist";
-
 const logger = new Logger({ name: "molvis-core" });
 
 class Molvis {
@@ -81,7 +81,34 @@ class Molvis {
   };
 
   public finalize = () => { };
+  public draw_atom(data: Map<string, any>) {
+    const x = Number(data.get("x"));
+    const y = Number(data.get("y"));
+    const z = Number(data.get("z"));
+    const name = data.get("name") as string;
+    const props = Object.fromEntries(data);
+    const [, entities] = this._executor.execute("draw_atom", { x, y, z, name, ...props });
+    return entities[0] as Atom;
+  }
+
+  public draw_bond(itom: Atom, jtom: Atom) {
+    const bond = this._system.add_bond(itom, jtom);
+    const path = [itom.xyz, jtom.xyz];
+    MeshBuilder.CreateTube(`bond:${bond.name}`, { path, radius: 0.1 }, this.scene);
+    return bond;
+  }
+
+  public remove_atom(atom: Atom) {
+    this._system.remove_atom(atom);
+    const mesh = this.scene.getMeshByName(`atom:${atom.name}`);
+    if (mesh) mesh.dispose();
+    const bonds = this.scene.meshes.filter(m => m.name.startsWith("bond:") && m.name.includes(atom.name));
+    for (const b of bonds) {
+      b.dispose();
+    }
+  }
 
 }
 
 export { Molvis };
+

--- a/core/src/mode/edit.ts
+++ b/core/src/mode/edit.ts
@@ -1,140 +1,74 @@
-class EditMode extends Mode {
-    private _draggingAtomMesh: Mesh | undefined = undefined;
-    private _draggingBondMesh: Mesh | undefined = undefined;
-    private _startAtom: Atom | undefined = undefined;
-    private _draggingAtom: Atom | undefined = undefined;
-    private _draggingBond: Bond | undefined = undefined;
-  
-    constructor(app: Molvis) {
-      super(ModeType.Edit, app);
-    }
-  
-    override _on_mouse_down(pointerInfo: PointerInfo) {
-      if (pointerInfo.event.button !== 0) {
-        return;
-      }
-      this._pos_on_mouse_down = this.get_pointer_xy();
-      const mesh = this._pick_mesh(pointerInfo)
-      if (mesh) {
-        if (mesh.name.startsWith("atom:")) {
-          const atomName = mesh.name.split(":")[1];
-          this._startAtom = this._system.current_frame.get_atom(
-            (atom: Atom) => atom.name === atomName,
-          );
-        }
+import { PointerInfo, MeshBuilder, Mesh, Vector3 } from "@babylonjs/core";
+import { BaseMode, ModeType } from "./base";
+import { Molvis } from "@molvis/core";
+import { Atom } from "../system";
+import { get_vec3_from_screen_with_depth } from "./utils";
+
+class EditMode extends BaseMode {
+  private _startAtom: Atom | null = null;
+  private _preview: Mesh | null = null;
+
+  constructor(app: Molvis) {
+    super(ModeType.Edit, app);
+  }
+
+  override _on_pointer_down(pi: PointerInfo) {
+    if (pi.event.button === 0) {
+      const mesh = this.pick_mesh();
+      if (mesh && mesh.name.startsWith("atom:")) {
+        const name = mesh.name.split(":")[1];
+        this._startAtom = this.system.get_atom(a => a.name === name) || null;
       } else {
-        const xyz = get_vec3_from_screen_with_depth(
-          this._scene,
-          pointerInfo.event.clientX,
-          pointerInfo.event.clientY,
-          10,
-        );
-  
-        const atomData = new Map<string, ItemProp>([
+        const pos = get_vec3_from_screen_with_depth(this.world.scene, pi.event.clientX, pi.event.clientY, 10);
+        this._startAtom = this.app.draw_atom(new Map([
           ["name", `atom_${Date.now()}`],
+          ["x", pos.x],
+          ["y", pos.y],
+          ["z", pos.z],
           ["type", "C"],
-          ["x", xyz.x],
-          ["y", xyz.y],
-          ["z", xyz.z],
-        ]);
-  
-        this._startAtom = this._app.draw_atom(atomData);
+        ]));
       }
-    }
-  
-    override _on_mouse_move(pointerInfo: PointerInfo) {
-      if (!this._startAtom || !this._pos_on_mouse_down) return;
-  
-      const xyz = get_vec3_from_screen_with_depth(
-        this._scene,
-        pointerInfo.event.clientX,
-        pointerInfo.event.clientY,
-        10,
-      );
-  
-      if (this._is_dragging && !this._draggingAtomMesh) {
-        const atomData = new Map<string, ItemProp>([
-          ["name", `atom_${Date.now()}`],
-          ["type", "C"],
-          ["x", xyz.x],
-          ["y", xyz.y],
-          ["z", xyz.z],
-        ]);
-  
-        // 创建临时原子，但不添加到系统中
-        this._draggingAtom = new Atom(atomData);
-        this._draggingBond = new Bond(this._draggingAtom, this._startAtom);
-        this._draggingAtomMesh = this._world.artist.draw_atom(this._draggingAtom);
-        this._draggingBondMesh = this._world.artist.draw_bond(this._draggingBond);
-      } else if (this._draggingAtomMesh) {
-        // 只更新网格位置，不更新系统数据
-        this._draggingAtom!.xyz = xyz;
-        this._draggingAtomMesh.position = xyz;
-  
-        // 更新键的位置和方向
-        if (this._draggingBondMesh) {
-          this._world.artist.draw_bond(this._draggingBond!, {
-            instance: this._draggingBondMesh,
-          });
-        }
+    } else if (pi.event.button === 2) {
+      const pick = pi.pickInfo?.pickedMesh;
+      if (pick && pick.name.startsWith("atom:")) {
+        const name = pick.name.split(":")[1];
+        const atom = this.system.get_atom(a => a.name === name);
+        if (atom) this.app.remove_atom(atom);
       }
-    }
-  
-    override _on_mouse_up(pointerInfo: PointerInfo) {
-      if (this._draggingAtomMesh && this._draggingAtom) {
-        // 鼠标释放时才将数据同步到系统中
-        const xyz = this._draggingAtomMesh.position;
-        const atomData = new Map<string, ItemProp>([
-          ["name", this._draggingAtom.name],
-          ["type", "C"],
-          ["x", xyz.x],
-          ["y", xyz.y],
-          ["z", xyz.z],
-        ]);
-  
-        // 添加原子到系统
-        const newAtom = this._app.draw_atom(atomData);
-  
-        // 添加键到系统
-        if (this._startAtom) {
-          this._app.draw_bond(this._startAtom, newAtom);
-        }
-  
-        // 清除临时网格
-        if (this._draggingBondMesh) {
-          this._draggingBondMesh.dispose();
-        }
-        this._draggingAtomMesh.dispose();
-      }
-  
-      // 重置所有临时变量
-      this._draggingAtomMesh = undefined;
-      this._startAtom = undefined;
-      this._draggingBondMesh = undefined;
-      this._draggingAtom = undefined;
-      this._pos_on_mouse_down = this.get_pointer_xy();
-      this._pos_on_mouse_down = this.get_pointer_xy();
     }
   }
-  
-  // class ManupulateMode extends Mode {
-  //   constructor(app: Molvis) {
-  //     super(ModeType.Manupulate, app);
-  //   }
-  
-  //   override _on_mouse_down(pointerInfo: PointerInfo) {}
-  
-  //   override _on_mouse_up(pointerInfo: PointerInfo) {}
-  
-  //   override _on_mouse_move(pointerInfo: PointerInfo) {}
-  
-  //   override _on_mouse_wheel(pointerInfo: PointerInfo) {}
-  
-  //   override _on_mouse_pick(pointerInfo: PointerInfo) {}
-  
-  //   override _on_mouse_tap(pointerInfo: PointerInfo) {}
-  
-  //   override _on_mouse_double_tap(pointerInfo: PointerInfo) {}
-  // }
-  
 
+  override _on_pointer_move(pi: PointerInfo) {
+    if (pi.event.buttons === 1 && this._startAtom) {
+      const pos = get_vec3_from_screen_with_depth(this.world.scene, pi.event.clientX, pi.event.clientY, 10);
+      if (!this._preview) {
+        this._preview = MeshBuilder.CreateSphere("preview", { diameter: 0.2 }, this.world.scene);
+        this._preview.isPickable = false;
+      }
+      this._preview.position.copyFrom(pos);
+    } else if (pi.event.buttons === 2) {
+      this.world.camera.target.addInPlace(new Vector3(-pi.event.movementX * 0.01, pi.event.movementY * 0.01, 0));
+    }
+  }
+
+  override _on_pointer_up(pi: PointerInfo) {
+    if (pi.event.button === 0 && this._startAtom && this._preview) {
+      const pos = this._preview.position.clone();
+      const newAtom = this.app.draw_atom(new Map([
+        ["name", `atom_${Date.now()}`],
+        ["x", pos.x],
+        ["y", pos.y],
+        ["z", pos.z],
+        ["type", "C"],
+      ]));
+      this.app.draw_bond(this._startAtom, newAtom);
+    }
+    if (this._preview) {
+      this._preview.dispose();
+      this._preview = null;
+    }
+    this._startAtom = null;
+  }
+}
+
+export { EditMode };

--- a/core/src/mode/index.ts
+++ b/core/src/mode/index.ts
@@ -10,6 +10,7 @@ const logger = new Logger({ name: "molvis-core" });
 
 import { ModeType, BaseMode } from "./base";
 import { ViewMode } from "./view";
+import { EditMode } from "./edit";
 
 class Mode {
 
@@ -34,14 +35,10 @@ class Mode {
                         case "1":
                             this.switch_mode(ModeType.View);
                             break;
-                        // case "2":
-                        //     logger.info("select mode");
-                        //     this.switch_mode(ModeType.Select);
-                        //     break;
-                        // case "3":
-                        //     logger.info("edit mode");
-                        //     this.switch_mode(ModeType.Edit);
-                        //     break;
+                        case "2":
+                            logger.info("edit mode");
+                            this.switch_mode(ModeType.Edit);
+                            break;
                         // case "4":
                         //   this._mode = this.switch_mode("manupulate");
                     }
@@ -56,9 +53,9 @@ class Mode {
             this._mode.finish();
         let _mode;
         switch (mode) {
-            // case "edit":
-            //     this._mode = new EditMode(this._system, this._world);
-            //     break;
+            case "edit":
+                _mode = new EditMode(this._app);
+                break;
             case "view":
                 _mode = new ViewMode(this._app);
                 break;
@@ -70,6 +67,7 @@ class Mode {
             default:
                 throw new Error(`unknown mode: ${mode}`);
         }
+        this._mode = _mode;
         return _mode;
     }
 }

--- a/core/src/mode/utils.ts
+++ b/core/src/mode/utils.ts
@@ -1,25 +1,28 @@
+import { AbstractMesh, Scene, Vector3, Matrix, RayHelper, Color3 } from "@babylonjs/core";
+
 function highlight_mesh(mesh: AbstractMesh) {
-    mesh.renderOutline = !mesh.renderOutline;
+  mesh.renderOutline = !mesh.renderOutline;
+}
+
+function get_vec3_from_screen_with_depth(
+  scene: Scene,
+  x: number,
+  y: number,
+  depth: number,
+  debug = false,
+): Vector3 {
+  const ray = scene.createPickingRay(
+    x,
+    y,
+    Matrix.Identity(),
+    scene.activeCamera,
+  );
+  const xyz = ray.origin.add(ray.direction.scale(depth));
+  if (debug) {
+    const rayHelper = new RayHelper(ray);
+    rayHelper.show(scene, new Color3(1, 1, 0.5));
   }
-  function get_vec3_from_screen_with_depth(
-    scene: Scene,
-    x: number,
-    y: number,
-    depth: number,
-    debug = false,
-  ): Vector3 {
-    // cast a ray from the camera to xy screen position
-    // get the Vector3 of the intersection point with a plane at depth
-    const ray = scene.createPickingRay(
-      x,
-      y,
-      Matrix.Identity(),
-      scene.activeCamera,
-    );
-    const xyz = ray.origin.add(ray.direction.scale(depth));
-    if (debug) {
-      const rayHelper = new RayHelper(ray);
-      rayHelper.show(scene, new Color3(1, 1, 0.5));
-    }
-    return xyz;
-  }
+  return xyz;
+}
+
+export { highlight_mesh, get_vec3_from_screen_with_depth };

--- a/core/src/system/frame.ts
+++ b/core/src/system/frame.ts
@@ -2,75 +2,63 @@ import { Vector3 } from "@babylonjs/core";
 import { Atom, Bond, Prop } from "./item";
 
 class Frame {
-    private _atoms: Atom[];
-    private _bonds: Bond[];
-    private _props: Map<string, Prop>;
+  private _atoms: Atom[];
+  private _bonds: Bond[];
+  private _props: Map<string, Prop>;
 
-    constructor() {
-        this._atoms = [];
-        this._bonds = [];
-        this._props = new Map();
+  constructor() {
+    this._atoms = [];
+    this._bonds = [];
+    this._props = new Map();
+  }
+
+  public add_atom(name: string, xyz: Vector3, props: Record<string, any>): Atom {
+    const atom = new Atom();
+    atom.set("name", name);
+    atom.set("xyz", xyz);
+    for (const key in props) {
+      atom.set(key, props[key]);
     }
+    this._atoms.push(atom);
+    return atom;
+  }
 
-    public add_atom(name: string, xyz: Vector3, props: Record<string, any>): Atom {
-        const atom = new Atom();
-        atom.set("name", name);
-        atom.set("xyz", xyz);
-        for (const key in props) {
-            atom.set(key, props[key]);
-        }
-        this._atoms.push(atom);
-        return atom;
-    }
+  public add_bond(itom: Atom, jtom: Atom, props: Record<string, any> = {}): Bond {
+    const bond = new Bond(itom, jtom, new Map(Object.entries(props)));
+    this._bonds.push(bond);
+    return bond;
+  }
 
+  public get_atom(fn: (atom: Atom) => boolean): Atom | undefined {
+    return this._atoms.find(fn);
+  }
 
-    // public add_bond = (
-    //   itom: Atom,
-    //   jtom: Atom,
-    //   data: Map<string, Prop> = new Map(),
-    // ): Bond => {
-    //   const bond = new Bond(itom, jtom, data);
-    //   this._bonds.push(bond);
-    //   return bond;
-    // };
+  public get_bond(fn: (bond: Bond) => boolean): Bond | undefined {
+    return this._bonds.find(fn);
+  }
 
-    // public get_atom = (fn: (atom: Atom) => boolean): Atom | undefined => {
-    //   return this._atoms.find(fn);
-    // };
+  public remove_atom(atom: Atom) {
+    this._atoms = this._atoms.filter(a => a !== atom);
+    this._bonds = this._bonds.filter(b => b.itom !== atom && b.jtom !== atom);
+  }
 
-    // public get_bond = (fn: (bond: Bond) => boolean): Bond | undefined => {
-    //   return this._bonds.find(fn);
-    // };
+  public remove_bond(bond: Bond) {
+    this._bonds = this._bonds.filter(b => b !== bond);
+  }
 
-    // get n_atoms(): number {
-    //   return this._atoms.length;
-    // }
+  get atoms(): Atom[] {
+    return this._atoms;
+  }
 
-    // get props(): Map<string, Prop> {
-    //   return this._props;
-    // }
+  get bonds(): Bond[] {
+    return this._bonds;
+  }
 
-    // get atoms(): Atom[] {
-    //   return this._atoms;
-    // }
-
-    // get bonds(): Bond[] {
-    //   return this._bonds;
-    // }
-
-    // set atoms(atoms: Atom[]) {
-    //   this._atoms = atoms;
-    // }
-
-    // set bonds(bonds: Bond[]) {
-    //   this._bonds = bonds;
-    // }
-
-    public clear() {
-        this._atoms = [];
-        this._bonds = [];
-        this._props = new Map();
-    }
+  public clear() {
+    this._atoms = [];
+    this._bonds = [];
+    this._props = new Map();
+  }
 }
 
 export { Frame };

--- a/core/src/system/index.ts
+++ b/core/src/system/index.ts
@@ -1,8 +1,9 @@
 import { Frame } from './frame';
-import { Atom } from './item';
+import { Atom, Bond } from './item';
 import { Trajectory } from './trajectory';
 import { Box } from './box';
 import { IEntity } from './base';
+import { Vector3 } from '@babylonjs/core';
 
 class System {
   private _selected: Atom[];
@@ -41,11 +42,25 @@ class System {
     return this._trajectory.prevFrame();
   }
 
+  public add_atom(name: string, xyz: Vector3, props: Record<string, any>) {
+    return this.current_frame.add_atom(name, xyz, props);
+  }
+
+  public add_bond(itom: Atom, jtom: Atom, props: Record<string, any> = {}) {
+    return this.current_frame.add_bond(itom, jtom, props);
+  }
+
+  public get_atom(fn: (atom: Atom) => boolean) {
+    return this.current_frame.get_atom(fn);
+  }
+
+  public remove_atom(atom: Atom) {
+    this.current_frame.remove_atom(atom);
+  }
+
   static random_atom_id(): string {
     const randomNum = Math.floor(Math.random() * 0x10000);
-
-    const hexID = randomNum.toString(16).padStart(4, "0");
-
+    const hexID = randomNum.toString(16).padStart(4, '0');
     return hexID;
   }
 
@@ -60,10 +75,7 @@ class System {
   get n_frames(): number {
     return this._trajectory.frames.length;
   }
-
 }
 
-
-
-export { System, Box };
+export { System, Box, Atom, Bond };
 export type { IEntity };

--- a/core/tests/system.test.ts
+++ b/core/tests/system.test.ts
@@ -1,4 +1,5 @@
 import { System, Frame } from "../src/system";
+import { Vector3 } from "@babylonjs/core";
 
 describe("System", () => {
   it("creates a trajectory and adds frames", () => {
@@ -15,3 +16,16 @@ describe("System", () => {
     expect(sys.trajectory.currentFrame).toBe(sys.trajectory.frames[1]);
   });
 });
+
+  it("handles atoms and bonds", () => {
+    const frame = new Frame();
+    const sys = new System();
+    sys.append_frame(frame);
+    const a1 = frame.add_atom("a1", new Vector3(0,0,0), {});
+    const a2 = frame.add_atom("a2", new Vector3(1,0,0), {});
+    frame.add_bond(a1, a2);
+    expect(frame.bonds.length).toBe(1);
+    frame.remove_atom(a1);
+    expect(frame.atoms.length).toBe(1);
+    expect(frame.bonds.length).toBe(0);
+  });


### PR DESCRIPTION
## Summary
- add vector picking utilities
- enhance system frame to support bonds
- expose atom/bond helpers from System and Molvis
- implement a rudimentary EditMode
- allow switching modes with key 2
- test atom/bond creation and removal

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684833a047848324823053fa8c3a4607