### PR TITLE
Implement edit mode and add jest tests

### DIFF
--- a/core/jest.config.ts
+++ b/core/jest.config.ts
@@ -1,28 +1,16 @@
 import type { Config } from "jest";
 
 const config: Config = {
+  preset: "ts-jest/presets/default-esm",
   testEnvironment: "node",
   transform: {
-    "^.+\\.(t|j)sx?$": [
-      "@swc/jest",
-      {
-        jsc: {
-          parser: {
-            syntax: "typescript",
-            tsx: true,
-            decorators: true,
-          },
-          target: "es2022",
-        },
-      },
-    ],
+    "^.+\\.(t|j)sx?$": ["ts-jest", { tsconfig: "tsconfig.json", useESM: true }],
   },
-  transformIgnorePatterns: ["/node_modules/(?!@babylonjs/.*)"],
-  extensionsToTreatAsEsm: [".ts"],
+  transformIgnorePatterns: ["/node_modules/"],
   rootDir: "./",
   moduleNameMapper: {
     "@molvis/core": "<rootDir>/src/index.ts",
-    "^@molvis/core/(.*)$": "<rootDir>/src/$1"
+    "^@molvis/core/(.*)$": "<rootDir>/src/$1",
   },
 };
 

--- a/core/src/app.ts
+++ b/core/src/app.ts
@@ -1,5 +1,5 @@
 import { Logger } from "tslog";
-import { Mode } from "./mode";
+import { ModeManager } from "./mode";
 import { System } from "./system";
 import { World } from "./world";
 import { Executor } from "./command";
@@ -12,7 +12,7 @@ class Molvis {
 
   private _world: World;
   private _system: System;
-  private _mode: Mode;
+  private _mode: ModeManager;
   private _executor: Executor;
   private _gui: GuiManager;
   // private _artist: ArtistGuild;
@@ -21,7 +21,7 @@ class Molvis {
     this._system = new System();
     this._world = new World(canvas);
     this._gui = new GuiManager(this);
-    this._mode = new Mode(this);
+    this._mode = new ModeManager(this);
     // this._artist = new ArtistGuild(this);
     this._executor = new Executor(this);
     logger.info("Molvis initialized");
@@ -43,7 +43,7 @@ class Molvis {
   //   return this._artist;
   // }
 
-  get mode(): Mode {
+  get mode(): ModeManager {
     return this._mode;
   }
 

--- a/core/src/mode/edit.ts
+++ b/core/src/mode/edit.ts
@@ -1,12 +1,14 @@
-import { PointerInfo } from "@babylonjs/core";
+import { PointerInfo, MeshBuilder, StandardMaterial, Color3, type Mesh } from "@babylonjs/core";
 import { get_vec3_from_screen_with_depth } from "./utils";
 import { BaseMode, ModeType } from "./base";
-import type { Molvis, Atom, Bond } from "@molvis/core";
+import type { Molvis, Atom } from "@molvis/core";
 import { draw_atom, draw_bond } from "../artist";
 import { System } from "../system";
 
 class EditMode extends BaseMode {
   private _startAtom: Atom | null = null;
+  private _previewAtom: Mesh | null = null;
+  private _previewBond: Mesh | null = null;
 
   constructor(app: Molvis) {
     super(ModeType.Edit, app);
@@ -20,6 +22,10 @@ class EditMode extends BaseMode {
         const name = mesh.name.substring(5);
         this._startAtom =
           this.system.current_frame.atoms.find((a) => a.name === name) || null;
+        // disable camera control when start dragging from an atom
+        this.world.camera.detachControl(
+          this.world.scene.getEngine().getRenderingCanvas(),
+        );
       } else {
         const xyz = get_vec3_from_screen_with_depth(
           this.world.scene,
@@ -40,16 +46,49 @@ class EditMode extends BaseMode {
     }
   }
 
+  override _on_pointer_move(pointerInfo: PointerInfo) {
+    super._on_pointer_move(pointerInfo);
+    if (this._startAtom && pointerInfo.event.buttons === 1) {
+      const xyz = get_vec3_from_screen_with_depth(
+        this.world.scene,
+        pointerInfo.event.clientX,
+        pointerInfo.event.clientY,
+        10,
+      );
+
+      if (!this._previewAtom) {
+        this._previewAtom = MeshBuilder.CreateSphere(
+          "preview_atom",
+          { diameter: 0.5 },
+          this.world.scene,
+        );
+        const mat = new StandardMaterial("preview_atom_mat", this.world.scene);
+        mat.diffuseColor = new Color3(0.5, 0.5, 0.5);
+        this._previewAtom.material = mat;
+
+        this._previewBond = MeshBuilder.CreateTube(
+          "preview_bond",
+          { path: [this._startAtom.xyz, xyz], radius: 0.05, updatable: true },
+          this.world.scene,
+        );
+        const bmat = new StandardMaterial("preview_bond_mat", this.world.scene);
+        bmat.diffuseColor = new Color3(0.8, 0.8, 0.8);
+        this._previewBond.material = bmat;
+      } else {
+        this._previewAtom.position = xyz;
+        MeshBuilder.CreateTube(
+          "preview_bond",
+          { path: [this._startAtom.xyz, xyz], instance: this._previewBond },
+        );
+      }
+    }
+  }
+
   override _on_pointer_up(pointerInfo: PointerInfo) {
     super._on_pointer_up(pointerInfo);
     if (pointerInfo.event.button === 0 && this._startAtom) {
-      if (this._is_dragging) {
-        const xyz = get_vec3_from_screen_with_depth(
-          this.world.scene,
-          pointerInfo.event.clientX,
-          pointerInfo.event.clientY,
-          10,
-        );
+      if (this._previewAtom) {
+        const xyz = this._previewAtom.position;
         const type = this._startAtom.get("type") as string | undefined;
         const newAtom = this.system.current_frame.add_atom(
           `a_${System.random_atom_id()}`,
@@ -65,6 +104,21 @@ class EditMode extends BaseMode {
         );
         draw_bond(this.app, bond, {});
       }
+
+      if (this._previewAtom) {
+        this._previewAtom.dispose();
+        this._previewAtom = null;
+      }
+      if (this._previewBond) {
+        this._previewBond.dispose();
+        this._previewBond = null;
+      }
+
+      this.world.camera.attachControl(
+        this.world.scene.getEngine().getRenderingCanvas(),
+        false,
+      );
+
       this._startAtom = null;
     } else if (pointerInfo.event.button === 2) {
       if (!this._is_dragging) {

--- a/core/src/mode/edit.ts
+++ b/core/src/mode/edit.ts
@@ -1,140 +1,94 @@
-class EditMode extends Mode {
-    private _draggingAtomMesh: Mesh | undefined = undefined;
-    private _draggingBondMesh: Mesh | undefined = undefined;
-    private _startAtom: Atom | undefined = undefined;
-    private _draggingAtom: Atom | undefined = undefined;
-    private _draggingBond: Bond | undefined = undefined;
-  
-    constructor(app: Molvis) {
-      super(ModeType.Edit, app);
-    }
-  
-    override _on_mouse_down(pointerInfo: PointerInfo) {
-      if (pointerInfo.event.button !== 0) {
-        return;
-      }
-      this._pos_on_mouse_down = this.get_pointer_xy();
-      const mesh = this._pick_mesh(pointerInfo)
-      if (mesh) {
-        if (mesh.name.startsWith("atom:")) {
-          const atomName = mesh.name.split(":")[1];
-          this._startAtom = this._system.current_frame.get_atom(
-            (atom: Atom) => atom.name === atomName,
-          );
-        }
+import { PointerInfo } from "@babylonjs/core";
+import { get_vec3_from_screen_with_depth } from "./utils";
+import { BaseMode, ModeType } from "./base";
+import type { Molvis, Atom, Bond } from "@molvis/core";
+import { draw_atom, draw_bond } from "../artist";
+import { System } from "../system";
+
+class EditMode extends BaseMode {
+  private _startAtom: Atom | null = null;
+
+  constructor(app: Molvis) {
+    super(ModeType.Edit, app);
+  }
+
+  override _on_pointer_down(pointerInfo: PointerInfo) {
+    super._on_pointer_down(pointerInfo);
+    if (pointerInfo.event.button === 0) {
+      const mesh = this.pick_mesh();
+      if (mesh && mesh.name.startsWith("atom:")) {
+        const name = mesh.name.substring(5);
+        this._startAtom =
+          this.system.current_frame.atoms.find((a) => a.name === name) || null;
       } else {
         const xyz = get_vec3_from_screen_with_depth(
-          this._scene,
+          this.world.scene,
           pointerInfo.event.clientX,
           pointerInfo.event.clientY,
           10,
         );
-  
-        const atomData = new Map<string, ItemProp>([
-          ["name", `atom_${Date.now()}`],
-          ["type", "C"],
-          ["x", xyz.x],
-          ["y", xyz.y],
-          ["z", xyz.z],
-        ]);
-  
-        this._startAtom = this._app.draw_atom(atomData);
+        const atomName = `a_${System.random_atom_id()}`;
+        const atom = this.system.current_frame.add_atom(
+          atomName,
+          xyz.x,
+          xyz.y,
+          xyz.z,
+          { type: "C" },
+        );
+        draw_atom(this.app, atom, {});
       }
-    }
-  
-    override _on_mouse_move(pointerInfo: PointerInfo) {
-      if (!this._startAtom || !this._pos_on_mouse_down) return;
-  
-      const xyz = get_vec3_from_screen_with_depth(
-        this._scene,
-        pointerInfo.event.clientX,
-        pointerInfo.event.clientY,
-        10,
-      );
-  
-      if (this._is_dragging && !this._draggingAtomMesh) {
-        const atomData = new Map<string, ItemProp>([
-          ["name", `atom_${Date.now()}`],
-          ["type", "C"],
-          ["x", xyz.x],
-          ["y", xyz.y],
-          ["z", xyz.z],
-        ]);
-  
-        // 创建临时原子，但不添加到系统中
-        this._draggingAtom = new Atom(atomData);
-        this._draggingBond = new Bond(this._draggingAtom, this._startAtom);
-        this._draggingAtomMesh = this._world.artist.draw_atom(this._draggingAtom);
-        this._draggingBondMesh = this._world.artist.draw_bond(this._draggingBond);
-      } else if (this._draggingAtomMesh) {
-        // 只更新网格位置，不更新系统数据
-        this._draggingAtom!.xyz = xyz;
-        this._draggingAtomMesh.position = xyz;
-  
-        // 更新键的位置和方向
-        if (this._draggingBondMesh) {
-          this._world.artist.draw_bond(this._draggingBond!, {
-            instance: this._draggingBondMesh,
-          });
-        }
-      }
-    }
-  
-    override _on_mouse_up(pointerInfo: PointerInfo) {
-      if (this._draggingAtomMesh && this._draggingAtom) {
-        // 鼠标释放时才将数据同步到系统中
-        const xyz = this._draggingAtomMesh.position;
-        const atomData = new Map<string, ItemProp>([
-          ["name", this._draggingAtom.name],
-          ["type", "C"],
-          ["x", xyz.x],
-          ["y", xyz.y],
-          ["z", xyz.z],
-        ]);
-  
-        // 添加原子到系统
-        const newAtom = this._app.draw_atom(atomData);
-  
-        // 添加键到系统
-        if (this._startAtom) {
-          this._app.draw_bond(this._startAtom, newAtom);
-        }
-  
-        // 清除临时网格
-        if (this._draggingBondMesh) {
-          this._draggingBondMesh.dispose();
-        }
-        this._draggingAtomMesh.dispose();
-      }
-  
-      // 重置所有临时变量
-      this._draggingAtomMesh = undefined;
-      this._startAtom = undefined;
-      this._draggingBondMesh = undefined;
-      this._draggingAtom = undefined;
-      this._pos_on_mouse_down = this.get_pointer_xy();
-      this._pos_on_mouse_down = this.get_pointer_xy();
     }
   }
-  
-  // class ManupulateMode extends Mode {
-  //   constructor(app: Molvis) {
-  //     super(ModeType.Manupulate, app);
-  //   }
-  
-  //   override _on_mouse_down(pointerInfo: PointerInfo) {}
-  
-  //   override _on_mouse_up(pointerInfo: PointerInfo) {}
-  
-  //   override _on_mouse_move(pointerInfo: PointerInfo) {}
-  
-  //   override _on_mouse_wheel(pointerInfo: PointerInfo) {}
-  
-  //   override _on_mouse_pick(pointerInfo: PointerInfo) {}
-  
-  //   override _on_mouse_tap(pointerInfo: PointerInfo) {}
-  
-  //   override _on_mouse_double_tap(pointerInfo: PointerInfo) {}
-  // }
-  
 
+  override _on_pointer_up(pointerInfo: PointerInfo) {
+    super._on_pointer_up(pointerInfo);
+    if (pointerInfo.event.button === 0 && this._startAtom) {
+      if (this._is_dragging) {
+        const xyz = get_vec3_from_screen_with_depth(
+          this.world.scene,
+          pointerInfo.event.clientX,
+          pointerInfo.event.clientY,
+          10,
+        );
+        const type = this._startAtom.get("type") as string | undefined;
+        const newAtom = this.system.current_frame.add_atom(
+          `a_${System.random_atom_id()}`,
+          xyz.x,
+          xyz.y,
+          xyz.z,
+          { type },
+        );
+        draw_atom(this.app, newAtom, {});
+        const bond = this.system.current_frame.add_bond(
+          this._startAtom,
+          newAtom,
+        );
+        draw_bond(this.app, bond, {});
+      }
+      this._startAtom = null;
+    } else if (pointerInfo.event.button === 2) {
+      if (!this._is_dragging) {
+        const mesh = this.pick_mesh();
+        if (mesh && mesh.name.startsWith("atom:")) {
+          const name = mesh.name.substring(5);
+          const atom = this.system.current_frame.atoms.find(
+            (a) => a.name === name,
+          );
+          if (atom) {
+            this.system.current_frame.remove_atom(atom);
+            for (const m of this.world.scene.meshes.slice()) {
+              if (
+                m.name === mesh.name ||
+                (m.name.startsWith("bond:") && m.name.includes(name))
+              ) {
+                m.dispose();
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+export { EditMode };

--- a/core/src/mode/edit.ts
+++ b/core/src/mode/edit.ts
@@ -9,6 +9,7 @@ class EditMode extends BaseMode {
   private _startAtom: Atom | null = null;
   private _previewAtom: Mesh | null = null;
   private _previewBond: Mesh | null = null;
+  private _hoverAtom: Atom | null = null;
 
   constructor(app: Molvis) {
     super(ModeType.Edit, app);
@@ -26,6 +27,7 @@ class EditMode extends BaseMode {
         this.world.camera.detachControl(
           this.world.scene.getEngine().getRenderingCanvas(),
         );
+        this._hoverAtom = null;
       } else {
         const xyz = get_vec3_from_screen_with_depth(
           this.world.scene,
@@ -49,37 +51,67 @@ class EditMode extends BaseMode {
   override _on_pointer_move(pointerInfo: PointerInfo) {
     super._on_pointer_move(pointerInfo);
     if (this._startAtom && pointerInfo.event.buttons === 1) {
-      const xyz = get_vec3_from_screen_with_depth(
-        this.world.scene,
-        pointerInfo.event.clientX,
-        pointerInfo.event.clientY,
-        10,
-      );
+      const mesh = this.pick_mesh();
+      let hover: Atom | null = null;
+      if (mesh && mesh.name.startsWith("atom:")) {
+        const name = mesh.name.substring(5);
+        const atom = this.system.current_frame.atoms.find((a) => a.name === name);
+        if (atom && atom !== this._startAtom) {
+          hover = atom;
+        }
+      }
 
-      if (!this._previewAtom) {
-        this._previewAtom = MeshBuilder.CreateSphere(
-          "preview_atom",
-          { diameter: 0.5 },
-          this.world.scene,
-        );
-        const mat = new StandardMaterial("preview_atom_mat", this.world.scene);
-        mat.diffuseColor = new Color3(0.5, 0.5, 0.5);
-        this._previewAtom.material = mat;
-
-        this._previewBond = MeshBuilder.CreateTube(
-          "preview_bond",
-          { path: [this._startAtom.xyz, xyz], radius: 0.05, updatable: true },
-          this.world.scene,
-        );
-        const bmat = new StandardMaterial("preview_bond_mat", this.world.scene);
-        bmat.diffuseColor = new Color3(0.8, 0.8, 0.8);
-        this._previewBond.material = bmat;
+      if (hover) {
+        this._hoverAtom = hover;
+        if (this._previewAtom) {
+          this._previewAtom.dispose();
+          this._previewAtom = null;
+        }
+        const path = [this._startAtom.xyz, hover.xyz];
+        if (!this._previewBond) {
+          this._previewBond = MeshBuilder.CreateTube(
+            "preview_bond",
+            { path, radius: 0.05, updatable: true },
+            this.world.scene,
+          );
+          const bmat = new StandardMaterial("preview_bond_mat", this.world.scene);
+          bmat.diffuseColor = new Color3(0.8, 0.8, 0.8);
+          this._previewBond.material = bmat;
+        } else {
+          MeshBuilder.CreateTube("preview_bond", { path, instance: this._previewBond });
+        }
       } else {
-        this._previewAtom.position = xyz;
-        MeshBuilder.CreateTube(
-          "preview_bond",
-          { path: [this._startAtom.xyz, xyz], instance: this._previewBond },
+        this._hoverAtom = null;
+        const xyz = get_vec3_from_screen_with_depth(
+          this.world.scene,
+          pointerInfo.event.clientX,
+          pointerInfo.event.clientY,
+          10,
         );
+        if (!this._previewAtom) {
+          this._previewAtom = MeshBuilder.CreateSphere(
+            "preview_atom",
+            { diameter: 0.5 },
+            this.world.scene,
+          );
+          const mat = new StandardMaterial("preview_atom_mat", this.world.scene);
+          mat.diffuseColor = new Color3(0.5, 0.5, 0.5);
+          this._previewAtom.material = mat;
+        }
+        this._previewAtom.position = xyz;
+        const path = [this._startAtom.xyz, xyz];
+        if (!this._previewBond) {
+          this._previewBond = MeshBuilder.CreateTube(
+            "preview_bond",
+            { path, radius: 0.05, updatable: true },
+            this.world.scene,
+          );
+          const bmat = new StandardMaterial("preview_bond_mat", this.world.scene);
+          bmat.diffuseColor = new Color3(0.8, 0.8, 0.8);
+          this._previewBond.material = bmat;
+        } else {
+          MeshBuilder.CreateTube("preview_bond", { path, instance: this._previewBond });
+        }
       }
     }
   }
@@ -87,7 +119,10 @@ class EditMode extends BaseMode {
   override _on_pointer_up(pointerInfo: PointerInfo) {
     super._on_pointer_up(pointerInfo);
     if (pointerInfo.event.button === 0 && this._startAtom) {
-      if (this._previewAtom) {
+      if (this._hoverAtom) {
+        const bond = this.system.current_frame.add_bond(this._startAtom, this._hoverAtom);
+        draw_bond(this.app, bond, {});
+      } else if (this._previewAtom) {
         const xyz = this._previewAtom.position;
         const type = this._startAtom.get("type") as string | undefined;
         const newAtom = this.system.current_frame.add_atom(
@@ -113,6 +148,7 @@ class EditMode extends BaseMode {
         this._previewBond.dispose();
         this._previewBond = null;
       }
+      this._hoverAtom = null;
 
       this.world.camera.attachControl(
         this.world.scene.getEngine().getRenderingCanvas(),

--- a/core/src/mode/index.ts
+++ b/core/src/mode/index.ts
@@ -8,6 +8,7 @@ const logger = new Logger({ name: "molvis-core" });
 import type { BaseMode } from "./base";
 import { ModeType } from "./base";
 import { ViewMode } from "./view";
+import { EditMode } from "./edit";
 
 class Mode {
   private _app: Molvis;
@@ -29,16 +30,15 @@ class Mode {
         case KeyboardEventTypes.KEYDOWN:
           switch (kbInfo.event.key) {
             case "1":
-              this.switch_mode(ModeType.View);
+              this._mode = this.switch_mode(ModeType.View);
               break;
             // case "2":
             //     logger.info("select mode");
             //     this.switch_mode(ModeType.Select);
             //     break;
-            // case "3":
-            //     logger.info("edit mode");
-            //     this.switch_mode(ModeType.Edit);
-            //     break;
+            case "3":
+              this._mode = this.switch_mode(ModeType.Edit);
+              break;
             // case "4":
             //   this._mode = this.switch_mode("manupulate");
           }
@@ -52,10 +52,10 @@ class Mode {
     if (this._mode) this._mode.finish();
     let _mode;
     switch (mode) {
-      // case "edit":
-      //     this._mode = new EditMode(this._system, this._world);
-      //     break;
-      case "view":
+      case ModeType.Edit:
+        _mode = new EditMode(this._app);
+        break;
+      case ModeType.View:
         _mode = new ViewMode(this._app);
         break;
       // case "select":

--- a/core/src/mode/index.ts
+++ b/core/src/mode/index.ts
@@ -10,7 +10,7 @@ import { ModeType } from "./base";
 import { ViewMode } from "./view";
 import { EditMode } from "./edit";
 
-class Mode {
+class ModeManager {
   private _app: Molvis;
   private _mode: BaseMode;
 
@@ -70,4 +70,4 @@ class Mode {
   };
 }
 
-export { Mode };
+export { ModeManager };

--- a/core/src/mode/utils.ts
+++ b/core/src/mode/utils.ts
@@ -1,25 +1,33 @@
-function highlight_mesh(mesh: AbstractMesh) {
-    mesh.renderOutline = !mesh.renderOutline;
+import {
+  AbstractMesh,
+  Color3,
+  Matrix,
+  RayHelper,
+  Scene,
+  Vector3,
+} from "@babylonjs/core";
+
+export function highlight_mesh(mesh: AbstractMesh) {
+  mesh.renderOutline = !mesh.renderOutline;
+}
+
+export function get_vec3_from_screen_with_depth(
+  scene: Scene,
+  x: number,
+  y: number,
+  depth: number,
+  debug = false,
+): Vector3 {
+  const ray = scene.createPickingRay(
+    x,
+    y,
+    Matrix.Identity(),
+    scene.activeCamera,
+  );
+  const xyz = ray.origin.add(ray.direction.scale(depth));
+  if (debug) {
+    const rayHelper = new RayHelper(ray);
+    rayHelper.show(scene, new Color3(1, 1, 0.5));
   }
-  function get_vec3_from_screen_with_depth(
-    scene: Scene,
-    x: number,
-    y: number,
-    depth: number,
-    debug = false,
-  ): Vector3 {
-    // cast a ray from the camera to xy screen position
-    // get the Vector3 of the intersection point with a plane at depth
-    const ray = scene.createPickingRay(
-      x,
-      y,
-      Matrix.Identity(),
-      scene.activeCamera,
-    );
-    const xyz = ray.origin.add(ray.direction.scale(depth));
-    if (debug) {
-      const rayHelper = new RayHelper(ray);
-      rayHelper.show(scene, new Color3(1, 1, 0.5));
-    }
-    return xyz;
-  }
+  return xyz;
+}

--- a/core/src/system/frame.ts
+++ b/core/src/system/frame.ts
@@ -2,84 +2,56 @@ import { Atom, Bond } from "./item";
 import type { IProp } from "./base";
 
 class Frame {
-    private _atoms: Atom[];
-    private _bonds: Bond[];
-    private _props: Map<string, IProp>;
+  private _atoms: Atom[];
+  private _bonds: Bond[];
+  private _props: Map<string, IProp>;
 
-    constructor(atoms: Atom[] = [], bonds: Bond[] = []) {
-        this._atoms = atoms;
-        this._bonds = bonds;
-        this._props = new Map();
-    }
+  constructor(atoms: Atom[] = [], bonds: Bond[] = []) {
+    this._atoms = atoms;
+    this._bonds = bonds;
+    this._props = new Map();
+  }
 
-    public add_atom(name: string, x: number, y: number, z: number, props?: Record<string, IProp>): Atom {
-        const atom = new Atom(name, x, y, z, props);
-        this._atoms.push(atom);
-        return atom;
-    }
+  public add_atom(
+    name: string,
+    x: number,
+    y: number,
+    z: number,
+    props: Record<string, IProp> = {},
+  ): Atom {
+    const atom = new Atom(name, x, y, z, props);
+    this._atoms.push(atom);
+    return atom;
+  }
 
-    public add_bond(itom: Atom, jtom: Atom, props?: Record<string, IProp>): Bond {
-        const bond = new Bond(itom, jtom, props);
-        this._bonds.push(bond);
-        return bond;
-    }
+  public add_bond(
+    itom: Atom,
+    jtom: Atom,
+    props: Record<string, IProp> = {},
+  ): Bond {
+    const bond = new Bond(itom, jtom, props);
+    this._bonds.push(bond);
+    return bond;
+  }
 
-    get atoms(): Atom[] {
-        return this._atoms;
-    }
+  public remove_atom(atom: Atom) {
+    this._atoms = this._atoms.filter((a) => a !== atom);
+    this._bonds = this._bonds.filter((b) => b.itom !== atom && b.jtom !== atom);
+  }
 
-    get bonds(): Bond[] {
-        return this._bonds;
-    }
+  get atoms(): Atom[] {
+    return this._atoms;
+  }
 
+  get bonds(): Bond[] {
+    return this._bonds;
+  }
 
-    // public add_bond = (
-    //   itom: Atom,
-    //   jtom: Atom,
-    //   data: Record<string, Prop[]>; = new Map(),
-    // ): Bond => {
-    //   const bond = new Bond(itom, jtom, data);
-    //   this._bonds.push(bond);
-    //   return bond;
-    // };
-
-    // public get_atom = (fn: (atom: Atom) => boolean): Atom | undefined => {
-    //   return this._atoms.find(fn);
-    // };
-
-    // public get_bond = (fn: (bond: Bond) => boolean): Bond | undefined => {
-    //   return this._bonds.find(fn);
-    // };
-
-    // get n_atoms(): number {
-    //   return this._atoms.length;
-    // }
-
-    // get props(): Record<string, Prop[]>; {
-    //   return this._props;
-    // }
-
-    // get atoms(): Atom[] {
-    //   return this._atoms;
-    // }
-
-    // get bonds(): Bond[] {
-    //   return this._bonds;
-    // }
-
-    // set atoms(atoms: Atom[]) {
-    //   this._atoms = atoms;
-    // }
-
-    // set bonds(bonds: Bond[]) {
-    //   this._bonds = bonds;
-    // }
-
-    public clear() {
-        this._atoms = [];
-        this._bonds = [];
-        this._props = new Map();
-    }
+  public clear() {
+    this._atoms = [];
+    this._bonds = [];
+    this._props = new Map();
+  }
 }
 
 export { Frame };

--- a/core/src/system/item.ts
+++ b/core/src/system/item.ts
@@ -3,7 +3,13 @@ import type { IProp } from "./base";
 import { Entity } from "./base";
 
 export class Atom extends Entity<IProp> {
-  constructor(name: string, x: number, y: number, z: number, props: Record<string, IProp> = {}) {
+  constructor(
+    name: string,
+    x: number,
+    y: number,
+    z: number,
+    props: Record<string, IProp> = {},
+  ) {
     super({
       name,
       x,
@@ -27,7 +33,6 @@ export class Atom extends Entity<IProp> {
 }
 
 export class Bond extends Entity<IProp> {
-
   private _itom: Atom;
   private _jtom: Atom;
 
@@ -46,6 +51,8 @@ export class Bond extends Entity<IProp> {
   }
 
   get name(): string {
-    return this.get("name") as string ?? `${this._itom.name}-${this._jtom.name}`;
+    return (
+      (this.get("name") as string) ?? `${this._itom.name}-${this._jtom.name}`
+    );
   }
 }

--- a/core/tests/editmode.test.ts
+++ b/core/tests/editmode.test.ts
@@ -83,6 +83,31 @@ describe('EditMode', () => {
     mode.finish();
   });
 
+  test('drag from atom onto existing atom only bonds', () => {
+    const system = new System();
+    const scene = createScene();
+    const camera = { detachControl: jest.fn(), attachControl: jest.fn() };
+    const app = { world: { scene, camera }, system, gui: {} } as unknown as Molvis;
+
+    const a1 = system.current_frame.add_atom('a1',0,0,0,{type:'C'});
+    const a2 = system.current_frame.add_atom('a2',1,0,0,{type:'C'});
+    scene.meshes.push({ name: 'atom:a1', dispose: jest.fn() });
+    scene.meshes.push({ name: 'atom:a2', dispose: jest.fn() });
+
+    scene.pick.mockReturnValueOnce({ hit: true, pickedMesh: { name: 'atom:a1' } });
+    scene.pick.mockReturnValueOnce({ hit: true, pickedMesh: { name: 'atom:a2' } });
+
+    const mode = new EditMode(app);
+    mode._on_pointer_down({ event: { button:0, clientX:0, clientY:0 } } as any);
+    mode._on_pointer_move({ event: { buttons:1, clientX:5, clientY:5 } } as any);
+    scene.pointerX = 5; scene.pointerY = 5;
+    mode._on_pointer_up({ event: { button:0, clientX:5, clientY:5 } } as any);
+
+    expect(system.current_frame.atoms.length).toBe(2);
+    expect(system.current_frame.bonds.length).toBe(1);
+    mode.finish();
+  });
+
   test('right click deletes atom', () => {
     const system = new System();
     const scene = createScene();

--- a/core/tests/editmode.test.ts
+++ b/core/tests/editmode.test.ts
@@ -1,0 +1,102 @@
+import { jest } from '@jest/globals';
+import { System } from '../src/system';
+import { EditMode } from '../src/mode/edit';
+import type { Molvis } from '../src/app';
+
+jest.mock('../src/artist', () => ({
+  draw_atom: jest.fn(),
+  draw_bond: jest.fn(),
+}));
+
+jest.mock('../src/mode/utils', () => ({
+  get_vec3_from_screen_with_depth: () => ({ x: 1, y: 0, z: 0 }),
+}));
+
+jest.mock('@babylonjs/core', () => {
+  class Vector3 {
+    constructor(public x:number, public y:number, public z:number) {}
+    add(v: any) { return new Vector3(this.x+v.x, this.y+v.y, this.z+v.z); }
+    scale(s: number){ return new Vector3(this.x*s, this.y*s, this.z*s); }
+    subtract(v: any){ return new Vector3(this.x - v.x, this.y - v.y, this.z - v.z); }
+    length(){ return Math.sqrt(this.x*this.x + this.y*this.y + this.z*this.z); }
+    copyFrom(v: any){ this.x=v.x; this.y=v.y; this.z=v.z; }
+  }
+  class Vector2 {
+    constructor(public x = 0, public y = 0) {}
+    subtract(v: any) { return new Vector2(this.x - v.x, this.y - v.y); }
+    length() { return Math.sqrt(this.x*this.x + this.y*this.y); }
+  }
+  return {
+    Vector3,
+    Vector2,
+    MeshBuilder: { CreateSphere: jest.fn(() => ({ dispose: jest.fn(), position: new Vector3(0,0,0) })), CreateTube: jest.fn(() => ({ dispose: jest.fn() })) },
+    StandardMaterial: class { constructor(public name:string){ this.diffuseColor=null; } },
+    Color3: class { constructor(public r:number, public g:number, public b:number){} static FromHexString(){ return new Color3(0,0,0); } },
+  };
+});
+
+function createScene() {
+  return {
+    pointerX:0,
+    pointerY:0,
+    meshes: [] as any[],
+    onPointerObservable:{add: jest.fn(), remove: jest.fn()},
+    onKeyboardObservable:{add: jest.fn(), remove: jest.fn()},
+    pick: jest.fn(() => ({ hit: false })),
+    getEngine: jest.fn(() => ({ getRenderingCanvas: jest.fn(()=>'canvas') })),
+  };
+}
+
+describe('EditMode', () => {
+  test('add atom on click', () => {
+    const system = new System();
+    const scene = createScene();
+    const camera = { detachControl: jest.fn(), attachControl: jest.fn() };
+    const app = { world: { scene, camera }, system, gui: {} } as unknown as Molvis;
+
+    const mode = new EditMode(app);
+    mode._on_pointer_down({ event: { button: 0, clientX: 0, clientY: 0 } } as any);
+    expect(system.current_frame.atoms.length).toBe(1);
+    mode.finish();
+  });
+
+  test('drag from atom creates bonded atom', () => {
+    const system = new System();
+    const scene = createScene();
+    const camera = { detachControl: jest.fn(), attachControl: jest.fn() };
+    const app = { world: { scene, camera }, system, gui: {} } as unknown as Molvis;
+
+    const start = system.current_frame.add_atom('a1',0,0,0,{type:'C'});
+    scene.meshes.push({ name: 'atom:a1', dispose: jest.fn() });
+    scene.pick.mockReturnValueOnce({ hit: true, pickedMesh: { name: 'atom:a1' } });
+
+    const mode = new EditMode(app);
+    mode._on_pointer_down({ event: { button:0, clientX:0, clientY:0 } } as any);
+    mode._on_pointer_move({ event: { buttons:1, clientX:1, clientY:1 } } as any);
+    scene.pointerX = 1; scene.pointerY = 1;
+    mode._on_pointer_up({ event: { button:0, clientX:1, clientY:1 } } as any);
+
+    expect(camera.detachControl).toHaveBeenCalled();
+    expect(camera.attachControl).toHaveBeenCalled();
+    expect(system.current_frame.atoms.length).toBe(2);
+    expect(system.current_frame.bonds.length).toBe(1);
+    mode.finish();
+  });
+
+  test('right click deletes atom', () => {
+    const system = new System();
+    const scene = createScene();
+    const camera = { detachControl: jest.fn(), attachControl: jest.fn() };
+    const app = { world: { scene, camera }, system, gui: {} } as unknown as Molvis;
+
+    const a = system.current_frame.add_atom('a1',0,0,0,{});
+    scene.meshes.push({ name: 'atom:a1', dispose: jest.fn() });
+    scene.pick.mockReturnValue({ hit: true, pickedMesh: { name: 'atom:a1' } });
+
+    const mode = new EditMode(app);
+    mode._on_pointer_down({ event: { button:2, clientX:0, clientY:0 } } as any);
+    mode._on_pointer_up({ event: { button:2, clientX:0, clientY:0 } } as any);
+    expect(system.current_frame.atoms.length).toBe(0);
+    mode.finish();
+  });
+});

--- a/core/tests/item.test.ts
+++ b/core/tests/item.test.ts
@@ -1,13 +1,22 @@
+jest.mock("@babylonjs/core", () => {
+  return {
+    Vector3: class {
+      constructor(
+        public x: number,
+        public y: number,
+        public z: number,
+      ) {}
+    },
+  };
+});
 import { Vector3 } from "@babylonjs/core";
-import { Atom } from "@molvis/core";
+import { Atom } from "../src/system/item";
 
 describe("Atom", () => {
-
-    it("test_init_atom", () => {
-        const atom = new Atom("H", 0, 0, 0, { charge: 1 });
-        expect(atom.name).toBe("H");
-        expect(atom.get("charge")).toBe(1);
-        expect(atom.xyz).toEqual(new Vector3(0, 0, 0));
-    })
-    
+  it("test_init_atom", () => {
+    const atom = new Atom("H", 0, 0, 0, { charge: 1 });
+    expect(atom.name).toBe("H");
+    expect(atom.get("charge")).toBe(1);
+    expect(atom.xyz).toEqual(new Vector3(0, 0, 0));
+  });
 });

--- a/package.json
+++ b/package.json
@@ -4,15 +4,12 @@
   "description": "interactive molecule visulization package",
   "author": "Roy Kid",
   "license": "SEE LICENSE IN LICENSE",
-  "workspaces": [
-    "core",
-    "standalone",
-    "widget"
-  ],
+  "workspaces": ["core", "standalone", "widget"],
   "scripts": {
     "dev:widget": "npm run dev -w widget",
     "dev:standalone": "npm run dev -w standalone",
-    "dev:core": "npm run dev -w core"
+    "dev:core": "npm run dev -w core",
+    "test": "npm run test -w core"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",


### PR DESCRIPTION
## Summary
- add root `npm test` script to run core tests
- configure Jest to use ts-jest with ES modules
- rewrite edit mode with atom creation, bonding, and deletion
- expose edit mode switching via keyboard
- add helpers and cleanup system classes
- fix and mock unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848940722188324a6ad549bad1c1309