### PR TITLE
Refine view mode menu

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -23,6 +23,7 @@
     "@babylonjs/gui": "^7.52.2",
     "@babylonjs/materials": "^7.52.2",
     "chroma-js": "^3.1.2",
-    "tslog": "^4.9.3"
+    "tslog": "^4.9.3",
+    "tweakpane": "^4.0.5"
   }
 }

--- a/core/src/mode/view.ts
+++ b/core/src/mode/view.ts
@@ -1,39 +1,128 @@
 import { BaseMode, ModeType } from "./base";
 import { Molvis } from "@molvis/core";
 import { PointerInfo } from "@babylonjs/core";
+import { Pane } from "tweakpane";
+
+class ViewModeMenu {
+  private container: HTMLDivElement;
+  private pane: Pane;
+
+  constructor(private vm: ViewMode) {
+    this.container = document.createElement("div");
+    this.container.style.position = "absolute";
+    document.body.appendChild(this.container);
+    this.pane = new Pane({ container: this.container });
+    this.pane.hidden = true;
+    this.build();
+  }
+
+  private build() {
+    this.pane.children.forEach((c) => this.pane.remove(c));
+
+    const viewFolder = this.pane.addFolder({ title: "View" });
+    const options = [
+      { text: "perspective", value: "perspective" },
+      { text: "ortho", value: "ortho" },
+      { text: "front", value: "front" },
+      { text: "back", value: "back" },
+      { text: "left", value: "left" },
+      { text: "right", value: "right" },
+    ];
+
+    viewFolder
+      .addBlade({
+        view: "list",
+        label: "mode",
+        options,
+        value: "perspective",
+      })
+      .on("change", (ev) => {
+        switch (ev.value) {
+          case "perspective":
+            this.vm.world.setPerspective();
+            break;
+          case "ortho":
+            this.vm.world.setOrthographic();
+            break;
+          case "front":
+            this.vm.world.viewFront();
+            break;
+          case "back":
+            this.vm.world.viewBack();
+            break;
+          case "left":
+            this.vm.world.viewLeft();
+            break;
+          case "right":
+            this.vm.world.viewRight();
+            break;
+        }
+      });
+
+    const tools = this.pane.addFolder({ title: "Tools" });
+    tools.addButton({ title: "snapshot" }).on("click", () => {
+      this.vm.world.takeScreenShot();
+    });
+  }
+
+  public show(x: number, y: number) {
+    this.container.style.left = `${x}px`;
+    this.container.style.top = `${y}px`;
+    this.pane.hidden = false;
+  }
+
+  public hide() {
+    this.pane.hidden = true;
+  }
+}
 
 class ViewMode extends BaseMode {
-
-    constructor(app: Molvis) {
-      super(ModeType.View, app);
-    }
-  
-    override _on_pointer_move(pointerInfo: PointerInfo) {
-        const mesh = this.pick_mesh();
-        const name = mesh ? mesh.name : "";
-        this.gui.updateInfoText(name);
-    }
-  
-    _on_press_e() {
-      const frame = this.system.next_frame();
-      this.app.artist.clear();
-      this.app.artist.do("draw_frame", frame);
-      // this.gui.updateFrameIndicator(
-      //   this.system.current_frame_index,
-      //   this.system.n_frames,
-      // );
-    }
-  
-    _on_press_q() {
-      const frame = this.system.prev_frame();
-      this.app.artist.clear();
-      this.app.artist.do("draw_frame", frame);
-      // this.gui.updateFrameIndicator(
-      //   this.system.current_frame_index,
-      //   this.system.n_frames,
-      // );
-    }
-    
+  private menu: ViewModeMenu;
+  constructor(app: Molvis) {
+    super(ModeType.View, app);
+    this.menu = new ViewModeMenu(this);
   }
-  
+
+  override _on_pointer_down(pointerInfo: PointerInfo) {
+    super._on_pointer_down(pointerInfo);
+    if (pointerInfo.event.button === 0) {
+      this.menu.hide();
+    }
+  }
+
+  override _on_pointer_up(pointerInfo: PointerInfo) {
+    super._on_pointer_up(pointerInfo);
+    if (pointerInfo.event.button === 2) {
+      pointerInfo.event.preventDefault();
+      this.menu.show(pointerInfo.event.clientX, pointerInfo.event.clientY);
+    }
+  }
+
+  override _on_pointer_move(pointerInfo: PointerInfo) {
+    const mesh = this.pick_mesh();
+    const name = mesh ? mesh.name : "";
+    this.gui.updateInfoText(name);
+  }
+
+  _on_press_e() {
+    const frame = this.system.next_frame();
+    this.app.artist.clear();
+    this.app.artist.do("draw_frame", frame);
+    // this.gui.updateFrameIndicator(
+    //   this.system.current_frame_index,
+    //   this.system.n_frames,
+    // );
+  }
+
+  _on_press_q() {
+    const frame = this.system.prev_frame();
+    this.app.artist.clear();
+    this.app.artist.do("draw_frame", frame);
+    // this.gui.updateFrameIndicator(
+    //   this.system.current_frame_index,
+    //   this.system.n_frames,
+    // );
+  }
+}
+
 export { ViewMode };

--- a/core/src/world/world.ts
+++ b/core/src/world/world.ts
@@ -24,7 +24,7 @@ class World {
   private _pipeline: Pipeline;
   private _boxMesh: LinesMesh | null = null;
 
-  constructor(canvas: HTMLCanvasElement, ) {
+  constructor(canvas: HTMLCanvasElement) {
     this._engine = this._initEngine(canvas);
     this._scene = this._initScene(this._engine);
     this._camera = this._initCamera();
@@ -99,7 +99,42 @@ class World {
   }
 
   public takeScreenShot() {
-    Tools.CreateScreenshot(this._engine, this._camera, {precision: 1.0});
+    Tools.CreateScreenshot(this._engine, this._camera, { precision: 1.0 });
+  }
+
+  public setPerspective() {
+    this._camera.mode = ArcRotateCamera.PERSPECTIVE_CAMERA;
+  }
+
+  public setOrthographic() {
+    this._camera.mode = ArcRotateCamera.ORTHOGRAPHIC_CAMERA;
+    const ratio =
+      this._engine.getRenderWidth() / this._engine.getRenderHeight();
+    const ortho = this._camera.radius;
+    this._camera.orthoLeft = -ortho;
+    this._camera.orthoRight = ortho;
+    this._camera.orthoBottom = -ortho / ratio;
+    this._camera.orthoTop = ortho / ratio;
+  }
+
+  public viewFront() {
+    this._camera.alpha = -Math.PI / 2;
+    this._camera.beta = Math.PI / 2;
+  }
+
+  public viewBack() {
+    this._camera.alpha = Math.PI / 2;
+    this._camera.beta = Math.PI / 2;
+  }
+
+  public viewLeft() {
+    this._camera.alpha = Math.PI;
+    this._camera.beta = Math.PI / 2;
+  }
+
+  public viewRight() {
+    this._camera.alpha = 0;
+    this._camera.beta = Math.PI / 2;
   }
 
   public render() {


### PR DESCRIPTION
## Summary
- remove the unused tpane helper
- build a Tweakpane menu directly in `ViewMode`
- enable camera perspective/orientation and snapshot functions

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68495935aa008324be9d296de5536797