### PR TITLE
Add expand modifier to pipeline

### DIFF
--- a/core/src/pipeline/base.ts
+++ b/core/src/pipeline/base.ts
@@ -33,7 +33,11 @@ class Pipeline {
     }
   };
 
-  public modify = (app: Molvis, selected: Mesh[], entity: IEntity[]) => {
+  public modify = (
+    app: Molvis,
+    selected: Mesh[],
+    entity: IEntity[],
+  ): [Mesh[], IEntity[]] => {
     let upstream_selected = selected;
     let upstream_entity = entity;
     for (let i = 0; i < this._modifiers.length; i++) {
@@ -44,7 +48,7 @@ class Pipeline {
         upstream_entity,
       );
     }
-    return selected;
+    return [upstream_selected, upstream_entity];
   };
 }
 

--- a/core/src/pipeline/expand.ts
+++ b/core/src/pipeline/expand.ts
@@ -1,0 +1,61 @@
+import { Vector3, Color3, HighlightLayer } from "@babylonjs/core";
+import type { Mesh } from "@babylonjs/core";
+import type { Molvis } from "@molvis/core";
+import type { IEntity } from "../system/base";
+import { Atom } from "../system";
+import type { IModifier } from "./base";
+import { registerModifier } from "./base";
+
+@registerModifier("expand")
+class Expand implements IModifier {
+  private _radius: number;
+  private _highlight: boolean;
+
+  constructor(args: { radius: number; highlight?: boolean }) {
+    this._radius = args.radius;
+    this._highlight = args.highlight ?? true;
+  }
+
+  public modify(
+    app: Molvis,
+    selected: Mesh[],
+    entities: IEntity[],
+  ): [Mesh[], IEntity[]] {
+    const newEntities: IEntity[] = [];
+    const newMeshes: Mesh[] = [];
+    const visited = new Set<IEntity>();
+    const atoms = app.system.current_frame.atoms;
+
+    for (let i = 0; i < entities.length; i++) {
+      const ent = entities[i];
+      if (!(ent instanceof Atom)) {
+        continue;
+      }
+      for (const atom of atoms) {
+        if (visited.has(atom)) {
+          continue;
+        }
+        const dist = Vector3.Distance(ent.xyz, atom.xyz);
+        if (dist <= this._radius) {
+          visited.add(atom);
+          newEntities.push(atom);
+          const mesh = app.scene.getMeshByName(`atom:${atom.name}`);
+          if (mesh) {
+            newMeshes.push(mesh as Mesh);
+          }
+        }
+      }
+    }
+
+    if (this._highlight && newMeshes.length > 0) {
+      const layer = new HighlightLayer("highlight_expand", app.scene);
+      for (const mesh of newMeshes) {
+        layer.addMesh(mesh as Mesh, Color3.Blue());
+      }
+    }
+
+    return [newMeshes, newEntities];
+  }
+}
+
+export { Expand };

--- a/core/src/pipeline/index.ts
+++ b/core/src/pipeline/index.ts
@@ -1,5 +1,6 @@
 import { Pipeline } from './base';
 import type { IModifier, ModifierConstructor } from './base';
 import "./select";
+import "./expand";
 export { Pipeline };
 export type { IModifier, ModifierConstructor };


### PR DESCRIPTION
## Summary
- support expanding selection by neighboring atoms
- fix return value of Pipeline.modify

## Testing
- `npm test -w core` *(fails: Module @swc/jest in the transform option was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68499033cf5c8324be267d6a8505ef8b