### PR TITLE
Add HDF5 utils and improve draw_frame

### DIFF
--- a/widget/pyproject.toml
+++ b/widget/pyproject.toml
@@ -9,13 +9,15 @@ requires-python = ">=3.10"
 version = "0.1.0"
 dependencies = [
     "anywidget",
-    "pyarrow"
+    "pyarrow",
+    "h5py"
 ]
 
 [project.optional-dependencies]
 dev = [
     "anywidget[dev]",
-    "pyarrow"
+    "pyarrow",
+    "h5py"
 ]
 
 [tool.black]

--- a/widget/src/molvis/__init__.py
+++ b/widget/src/molvis/__init__.py
@@ -1,1 +1,3 @@
 from .widget import Molvis
+
+__all__ = ["Molvis"]

--- a/widget/src/molvis/utils.py
+++ b/widget/src/molvis/utils.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import io
+from typing import Any, Mapping
+
+import h5py
+import numpy as np
+import molpy as mp
+
+
+def frame_to_dict(frame: mp.Frame) -> dict[str, Any]:
+    """Convert a :class:`molpy.Frame` into a plain dictionary.
+
+    The upstream ``molpy`` package currently lacks a ``to_dict`` method for
+    ``Frame`` objects.  This helper mirrors the expected behaviour by extracting
+    all datasets and scalars from the frame into standard Python types.
+    """
+    if hasattr(frame, "to_dict"):
+        return frame.to_dict()  # type: ignore[attr-defined]
+
+    data: dict[str, Any] = {}
+    for key in getattr(frame, "_tree").keys():  # type: ignore[attr-defined]
+        ds = frame[key]
+        data[key] = {name: ds[name].values.tolist() for name in ds.data_vars}
+    if getattr(frame, "box", None) is not None:
+        data["box"] = frame.box.to_dict()
+    data.update(getattr(frame, "_scalars", {}))
+    return data
+
+
+def to_h5py(data: Mapping[str, Any]) -> bytes:
+    """Serialise a mapping of arrays to an in-memory HDF5 file."""
+    buffer = io.BytesIO()
+    with h5py.File(buffer, "w") as h5file:
+        for key, value in data.items():
+            arr = np.asarray(value)
+            if arr.dtype.kind in {"U", "O"}:
+                dtype = h5py.string_dtype(encoding="utf-8")
+                h5file.create_dataset(key, data=arr.astype("S"), dtype=dtype)
+            else:
+                h5file.create_dataset(key, data=arr)
+    buffer.seek(0)
+    return buffer.getvalue()

--- a/widget/tests/test_utils.py
+++ b/widget/tests/test_utils.py
@@ -1,0 +1,56 @@
+import os
+from io import BytesIO
+
+import h5py
+import numpy as np
+import molpy
+
+from molvis.utils import frame_to_dict, to_h5py
+from molvis.widget import Molvis
+
+
+def _make_dummy_widget():
+    os.makedirs("/workspaces/molvis/widget/dist", exist_ok=True)
+    with open("/workspaces/molvis/widget/dist/index.js", "w") as fp:
+        fp.write("console.log('dummy')")
+
+    class Dummy(Molvis):
+        def __init__(self):
+            super().__init__()
+            self.last = None
+
+        def send_cmd(self, method, params, buffers):
+            self.last = (method, params, buffers)
+            return self
+
+    return Dummy()
+
+
+def test_frame_to_dict():
+    f = molpy.core.Frame()
+    f["atoms"] = {"id": [0], "x": [0.0], "y": [0.0], "z": [0.0]}
+    d = frame_to_dict(f)
+    assert "atoms" in d
+    assert d["atoms"]["id"] == [0]
+
+
+def test_to_h5py_roundtrip():
+    data = {"x": [1, 2, 3], "y": [4, 5, 6]}
+    buf = to_h5py(data)
+    with h5py.File(BytesIO(buf), "r") as h5:
+        assert np.allclose(h5["x"][:], data["x"])
+        assert np.allclose(h5["y"][:], data["y"])
+
+
+def test_draw_frame_sends_buffers():
+    f = molpy.core.Frame()
+    f["atoms"] = {"id": [0], "x": [0.0], "y": [0.0], "z": [0.0], "name": ["H"]}
+    f["bonds"] = {"i": [0], "j": [0]}
+
+    w = _make_dummy_widget()
+    w.draw_frame(f)
+    assert w.last is not None
+    method, params, buffers = w.last
+    assert method == "draw_frame"
+    assert isinstance(buffers[0], (bytes, bytearray))
+    assert len(buffers) == 2


### PR DESCRIPTION
## Summary
- support converting molpy Frames to dictionaries and HDF5 bytes
- update widget `draw_frame` to send HDF5 buffers
- add unit tests for new utilities
- include h5py as dependency

## Testing
- `pytest -q widget/tests/test_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_6849d86058288324a1617b739cefaae4