### PR TITLE
feat(core): headless glTF/GLB exporter for ball-and-stick scenes

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -58,6 +58,7 @@
     "@babylonjs/gui": "^9.10.1",
     "@babylonjs/inspector": "^9.10.1",
     "@babylonjs/materials": "^9.10.1",
+    "@babylonjs/serializers": "^9.10.1",
     "@molcrafts/molrs": "^0.1.2",
     "tslog": "^4.10.2"
   },

--- a/core/scripts/gen-molecule-glb.mts
+++ b/core/scripts/gen-molecule-glb.mts
@@ -1,0 +1,51 @@
+/**
+ * Generate a .glb from a molecular structure file using molvis's own glTF
+ * exporter — the same ball-and-stick geometry the engine renders, serialized
+ * headlessly (no browser). This is what produces the docs demo asset; there is
+ * no hand-written geometry anywhere.
+ *
+ *   npx tsx core/scripts/gen-molecule-glb.mts <input.sdf|xyz|pdb|...> <out.glb>
+ *
+ * Runs in Node by initializing the molrs WASM (a wasm-bindgen `web` target)
+ * with the packaged .wasm bytes, then reusing core's reader + exporter.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { NullEngine } from "@babylonjs/core";
+import initMolrs from "@molcrafts/molrs";
+import { exportFrameToGLB } from "../src/export/gltf";
+import { readFrames } from "../src/io/reader";
+
+async function main(): Promise<void> {
+  const [input, output] = process.argv.slice(2);
+  if (!input || !output) {
+    throw new Error("usage: gen-molecule-glb.mts <input structure> <out.glb>");
+  }
+
+  // molrs is a wasm-bindgen "web" target: initialize it with the packaged bytes.
+  const require = createRequire(import.meta.url);
+  const molrsDir = dirname(require.resolve("@molcrafts/molrs"));
+  await initMolrs(readFileSync(join(molrsDir, "molwasm_bg.wasm")));
+
+  const frames = readFrames(readFileSync(input, "utf8"), input);
+  if (frames.length === 0) throw new Error(`no frames parsed from ${input}`);
+  const frame = frames[0];
+
+  const atoms = frame.getBlock("atoms");
+  const bonds = frame.getBlock("bonds");
+  console.log(
+    `parsed ${input}: ${atoms?.nrows() ?? 0} atoms, ${bonds?.nrows() ?? 0} bonds`,
+  );
+
+  const engine = new NullEngine();
+  const bytes = await exportFrameToGLB(frame, engine);
+  writeFileSync(output, bytes);
+  console.log(`wrote ${output} (${(bytes.length / 1024).toFixed(1)} KB)`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/core/src/app.ts
+++ b/core/src/app.ts
@@ -15,6 +15,7 @@ import { SetRepresentationCommand } from "./commands/representation";
 import { defaultMolvisConfig, type MolvisConfig } from "./config";
 import { createMolvisDOM, registerWebComponents } from "./dom_helpers";
 import { EventEmitter, type MolvisEventMap } from "./events";
+import { exportFrameToGLB, type GltfExportOptions } from "./export/gltf";
 import { FrameRenderScheduler } from "./frame_render_scheduler";
 import { viewAtomCoords } from "./io/atom_coords";
 import { ModeManager, ModeType } from "./mode";
@@ -504,6 +505,22 @@ export class MolvisApp {
           format: opts.format,
         }),
     );
+  }
+
+  /**
+   * Export the current frame as a self-contained binary glTF (`.glb`) of the
+   * ball-and-stick scene — real sphere/cylinder geometry carrying the active
+   * theme's colours and radii, viewable in any glTF viewer with zero molvis
+   * runtime. Reuses the render buffers, so the model matches what is drawn.
+   * See {@link exportFrameToGLB}.
+   */
+  public async exportGLTF(options?: GltfExportOptions): Promise<Uint8Array> {
+    const frame = this.frame;
+    if (!frame) throw new Error("exportGLTF: no frame loaded to export");
+    return exportFrameToGLB(frame, this._engine, {
+      styleManager: this._styleManager,
+      ...options,
+    });
   }
 
   private _syncAnchoredOverlays(frame: Frame): void {

--- a/core/src/export/gltf.ts
+++ b/core/src/export/gltf.ts
@@ -1,0 +1,200 @@
+import {
+  Color3,
+  type Engine,
+  Mesh,
+  MeshBuilder,
+  PBRMetallicRoughnessMaterial,
+  Quaternion,
+  Scene,
+  Vector3,
+} from "@babylonjs/core";
+import type { Frame } from "@molcrafts/molrs";
+import { buildAtomBuffers } from "../artist/atom_buffer";
+import { buildBondBuffers } from "../artist/bond_buffer";
+import { StyleManager } from "../artist/style_manager";
+
+/**
+ * Options for {@link exportFrameToGLB}. Defaults produce a matte, OVITO-style
+ * ball-and-stick model that renders identically in any glTF viewer.
+ */
+export interface GltfExportOptions {
+  /** PBR roughness. High = matte (default 0.9). */
+  roughness?: number;
+  /** PBR metalness (default 0). */
+  metallic?: number;
+  /** Latitude/longitude segments per atom sphere (default 16). */
+  sphereSegments?: number;
+  /** Radial tessellation per bond cylinder (default 12). */
+  bondTessellation?: number;
+  /**
+   * Reuse an existing StyleManager (so exported colours/radii match the live
+   * scene's theme and representation). Defaults to a fresh ClassicTheme manager.
+   */
+  styleManager?: StyleManager;
+}
+
+const UP = Vector3.Up();
+
+/**
+ * Serialize a molecular {@link Frame} to a self-contained binary glTF (.glb).
+ *
+ * Geometry and colours come from molvis's own render buffers
+ * ({@link buildAtomBuffers} / {@link buildBondBuffers}) — the exported model is
+ * the same ball-and-stick the engine draws, just as real triangle meshes
+ * instead of GPU impostors. Atoms occlude the buried ends of bonds through
+ * ordinary opaque depth; bond halves are split-coloured by their end atoms.
+ *
+ * Runs headless: it only needs a Babylon `Engine` (a `NullEngine` is fine) —
+ * no canvas, WebGL, or render loop. The `@babylonjs/serializers` module is
+ * loaded lazily so it stays out of the main bundle (mirrors the inspector).
+ *
+ * @param frame  Frame carrying an `"atoms"` block (and optionally a `"bonds"` block).
+ * @param engine Babylon engine used to host the throwaway export scene.
+ * @returns The `.glb` file as bytes.
+ */
+export async function exportFrameToGLB(
+  frame: Frame,
+  engine: Engine,
+  options?: GltfExportOptions,
+): Promise<Uint8Array> {
+  const atomsBlock = frame.getBlock("atoms");
+  if (!atomsBlock || atomsBlock.nrows() === 0) {
+    throw new Error("exportFrameToGLB: frame has no atoms to export");
+  }
+
+  const roughness = options?.roughness ?? 0.9;
+  const metallic = options?.metallic ?? 0;
+  const sphereSegments = options?.sphereSegments ?? 16;
+  const bondTessellation = options?.bondTessellation ?? 12;
+
+  const scene = new Scene(engine);
+  try {
+    const styleManager = options?.styleManager ?? new StyleManager(scene);
+
+    // Colour groups: one merged mesh + one material per distinct RGB. Molecular
+    // scenes have only a handful of element colours, so this stays tiny and
+    // needs no glTF extensions to render everywhere.
+    const groups = new Map<string, { color: Color3; meshes: Mesh[] }>();
+    const addToGroup = (mesh: Mesh, r: number, g: number, b: number): void => {
+      const key = `${Math.round(r * 4096)},${Math.round(g * 4096)},${Math.round(b * 4096)}`;
+      let group = groups.get(key);
+      if (!group) {
+        group = { color: new Color3(r, g, b), meshes: [] };
+        groups.set(key, group);
+      }
+      group.meshes.push(mesh);
+    };
+
+    // Atoms → spheres. instanceData = [x, y, z, radius]; instanceColor = linear RGBA.
+    const atomBuffers = buildAtomBuffers(atomsBlock, styleManager, 0);
+    const atomData = atomBuffers.get("instanceData");
+    const atomColor = atomBuffers.get("instanceColor");
+    if (!atomData || !atomColor) {
+      throw new Error(
+        "exportFrameToGLB: atom buffers missing expected columns",
+      );
+    }
+    const atomCount = atomsBlock.nrows();
+    for (let i = 0; i < atomCount; i++) {
+      const o = i * 4;
+      const radius = atomData[o + 3];
+      if (radius <= 0) continue;
+      const sphere = MeshBuilder.CreateSphere(
+        `atom${i}`,
+        { diameter: radius * 2, segments: sphereSegments },
+        scene,
+      );
+      sphere.position.set(atomData[o], atomData[o + 1], atomData[o + 2]);
+      addToGroup(sphere, atomColor[o], atomColor[o + 1], atomColor[o + 2]);
+    }
+
+    // Bonds → two split-coloured half cylinders per (sub-)bond instance.
+    const bondsBlock = frame.getBlock("bonds");
+    if (bondsBlock && bondsBlock.nrows() > 0) {
+      const bond = buildBondBuffers(bondsBlock, atomsBlock, atomColor, 0, {
+        radius: styleManager.getBondStyle(1).radius,
+      });
+      if (bond) {
+        const d0 = bond.buffers.get("instanceData0");
+        const d1 = bond.buffers.get("instanceData1");
+        const c0 = bond.buffers.get("instanceColor0");
+        const c1 = bond.buffers.get("instanceColor1");
+        if (d0 && d1 && c0 && c1) {
+          for (let k = 0; k < bond.instanceCount; k++) {
+            const o = k * 4;
+            const radius = d0[o + 3];
+            if (radius <= 0) continue;
+            const center = new Vector3(d0[o], d0[o + 1], d0[o + 2]);
+            const half = new Vector3(d1[o], d1[o + 1], d1[o + 2]).scale(
+              d1[o + 3] * 0.5,
+            );
+            const p0 = center.subtract(half); // end at atom of colour0
+            const p1 = center.add(half); // end at atom of colour1
+            addCylinder(scene, p0, center, radius, bondTessellation, (m) =>
+              addToGroup(m, c0[o], c0[o + 1], c0[o + 2]),
+            );
+            addCylinder(scene, center, p1, radius, bondTessellation, (m) =>
+              addToGroup(m, c1[o], c1[o + 1], c1[o + 2]),
+            );
+          }
+        }
+      }
+    }
+
+    // Merge each colour group and give it one matte PBR material.
+    let materialIndex = 0;
+    for (const group of groups.values()) {
+      const merged = Mesh.MergeMeshes(
+        group.meshes,
+        true, // dispose sources
+        true, // allow 32-bit indices (scenes exceed 65k verts fast)
+        undefined,
+        false,
+        false,
+      );
+      if (!merged) continue;
+      const mat = new PBRMetallicRoughnessMaterial(
+        `mat${materialIndex++}`,
+        scene,
+      );
+      mat.baseColor = group.color; // already linear, matching glTF baseColorFactor
+      mat.metallic = metallic;
+      mat.roughness = roughness;
+      merged.material = mat;
+    }
+
+    const { GLTF2Export } = await import("@babylonjs/serializers");
+    const data = await GLTF2Export.GLBAsync(scene, "molecule");
+    const blob = data.files["molecule.glb"] as Blob;
+    return new Uint8Array(await blob.arrayBuffer());
+  } finally {
+    scene.dispose();
+  }
+}
+
+/**
+ * Add a capped cylinder spanning `from`→`to` (Babylon cylinders are Y-aligned
+ * and centred, so we place the midpoint and rotate +Y onto the bond axis).
+ */
+function addCylinder(
+  scene: Scene,
+  from: Vector3,
+  to: Vector3,
+  radius: number,
+  tessellation: number,
+  register: (mesh: Mesh) => void,
+): void {
+  const axis = to.subtract(from);
+  const height = axis.length();
+  if (height < 1e-6) return;
+  const cyl = MeshBuilder.CreateCylinder(
+    "bond",
+    { height, diameter: radius * 2, tessellation, cap: Mesh.CAP_ALL },
+    scene,
+  );
+  cyl.position = from.add(to).scale(0.5);
+  const q = new Quaternion();
+  Quaternion.FromUnitVectorsToRef(UP, axis.scale(1 / height), q);
+  cyl.rotationQuaternion = q;
+  register(cyl);
+}

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -143,6 +143,7 @@ export {
   type Listener,
   type MolvisEventMap,
 } from "./events";
+export { exportFrameToGLB, type GltfExportOptions } from "./export/gltf";
 export { ModeType } from "./mode";
 export { AssignColorModifier } from "./modifiers/AssignColorModifier";
 export { ColorByPropertyModifier } from "./modifiers/ColorByPropertyModifier";

--- a/core/tests/gltf_export.test.ts
+++ b/core/tests/gltf_export.test.ts
@@ -1,0 +1,63 @@
+import { NullEngine } from "@babylonjs/core";
+import { Block, Frame } from "@molcrafts/molrs";
+import { describe, expect, it } from "@rstest/core";
+import "./setup_wasm";
+import { exportFrameToGLB } from "../src/export/gltf";
+
+/** A minimal C–O frame with one bond. */
+function makeFrame(): Frame {
+  const frame = new Frame();
+  const atoms = new Block();
+  atoms.setColF("x", new Float64Array([0, 1.2]));
+  atoms.setColF("y", new Float64Array([0, 0]));
+  atoms.setColF("z", new Float64Array([0, 0]));
+  atoms.setColStr("element", ["C", "O"]);
+  frame.insertBlock("atoms", atoms);
+  const bonds = new Block();
+  bonds.setColU32("atomi", new Uint32Array([0]));
+  bonds.setColU32("atomj", new Uint32Array([1]));
+  frame.insertBlock("bonds", bonds);
+  return frame;
+}
+
+describe("exportFrameToGLB", () => {
+  it("serializes a frame to a valid, matte, per-element binary glTF", async () => {
+    const engine = new NullEngine();
+    try {
+      const bytes = await exportFrameToGLB(makeFrame(), engine);
+      const dv = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+
+      // GLB container: magic "glTF", version 2, self-consistent length.
+      expect(dv.getUint32(0, true)).toBe(0x46546c67);
+      expect(dv.getUint32(4, true)).toBe(2);
+      expect(dv.getUint32(8, true)).toBe(bytes.byteLength);
+
+      // JSON chunk (after the 12-byte header + 8-byte chunk header).
+      const jsonLen = dv.getUint32(12, true);
+      const json = JSON.parse(
+        new TextDecoder().decode(bytes.subarray(20, 20 + jsonLen)),
+      );
+
+      // C and O give two colour groups → two matte, opaque materials.
+      expect(json.materials).toHaveLength(2);
+      for (const m of json.materials) {
+        expect(m.pbrMetallicRoughness.metallicFactor).toBe(0);
+        expect(m.pbrMetallicRoughness.roughnessFactor).toBeGreaterThan(0.5);
+      }
+      expect(json.meshes).toHaveLength(2);
+    } finally {
+      engine.dispose();
+    }
+  });
+
+  it("throws when the frame has no atoms", async () => {
+    const engine = new NullEngine();
+    try {
+      await expect(exportFrameToGLB(new Frame(), engine)).rejects.toThrow(
+        /no atoms/,
+      );
+    } finally {
+      engine.dispose();
+    }
+  });
+});


### PR DESCRIPTION
## What

Adds a real glTF/GLB exporter to `molvis-core` so a `Frame` can be serialized to a self-contained `.glb` of the ball-and-stick scene — real sphere/cylinder geometry viewable in any glTF viewer (`<model-viewer>`, Blender, three.js) with **zero molvis runtime**.

- `exportFrameToGLB(frame, engine, options?)` — `core/src/export/gltf.ts`
- `MolvisApp.exportGLTF(options?)` — convenience wrapper using the app's engine + current frame + theme
- `core/scripts/gen-molecule-glb.mts` — CLI: any structure file → `.glb` via the molrs reader + the exporter

## How it stays faithful (no duplicated logic)

The exporter calls molvis's **own** `buildAtomBuffers` / `buildBondBuffers`, then turns the resulting instance data into real capped `MeshBuilder` primitives. So exported colours (CPK/element theme, linear-space), radii, split-coloured bond halves, and **bond orders** (double/triple → parallel cylinders) match exactly what the engine draws. Atoms occlude buried bond ends through ordinary opaque depth — no impostor tricks needed.

Geometry is grouped by colour into one merged mesh + one matte PBR material each (metallic 0, roughness 0.9), so it needs no glTF extensions and renders everywhere.

## Headless

Runs under a Babylon `NullEngine` — no canvas/WebGL/render loop. `@babylonjs/serializers` is lazy-loaded (`await import(...)`) exactly like the inspector, so it stays out of the main bundle. Verified end-to-end in Node: aspirin SDF → 21 atoms/21 bonds → valid 726 KB `.glb`, rendered correctly in `<model-viewer>` (matte, CPK colours, clean junctions, aromatic double bonds visible).

## Notes / follow-ups

- `core/package.json` gains `@babylonjs/serializers` (was only transitive).
- Test `core/tests/gltf_export.test.ts` added (mirrors existing Frame-construction pattern). Core `tsc --noEmit` and biome pass on all touched files. The full pre-commit/pre-push hooks (whole-repo `build:all` + browser rstest) could not run in the isolated worktree — CI on this PR is the real gate.
- Follow-up: wire an "Export ▸ glTF" item into the sidebar export menu (page/vsc-ext) so it's user-accessible in-app, not just programmatic.

Draft — opening for review.